### PR TITLE
Allow to use Service references everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Innmind\DI\Service` can now be used everywhere a service can be referenced
+
 ### Fixed
 
 - `Innmind\Framework\Http\To` no longer raise Psalm errors when used as argument to `Application::route()`

--- a/src/Cli/Command/Defer.php
+++ b/src/Cli/Command/Defer.php
@@ -7,14 +7,17 @@ use Innmind\CLI\{
     Command,
     Console,
 };
-use Innmind\DI\Container;
+use Innmind\DI\{
+    Container,
+    Service,
+};
 
 /**
  * @internal
  */
 final class Defer implements Command
 {
-    private string $service;
+    private string|Service $service;
     private Container $locate;
     /** @var callable(Command): Command */
     private $map;
@@ -24,7 +27,7 @@ final class Defer implements Command
      * @param callable(Command): Command $map
      */
     public function __construct(
-        string $service,
+        string|Service $service,
         Container $locate,
         callable $map,
     ) {

--- a/src/Http/Service.php
+++ b/src/Http/Service.php
@@ -7,15 +7,18 @@ use Innmind\Http\{
     ServerRequest,
     Response,
 };
-use Innmind\DI\Container;
+use Innmind\DI\{
+    Container,
+    Service as Ref,
+};
 use Innmind\Router\Route\Variables;
 
 final class Service
 {
     private Container $container;
-    private string $service;
+    private string|Ref $service;
 
-    private function __construct(Container $container, string $service)
+    private function __construct(Container $container, string|Ref $service)
     {
         $this->container = $container;
         $this->service = $service;
@@ -30,7 +33,7 @@ final class Service
         return ($this->container)($this->service)($request, $variables);
     }
 
-    public static function of(Container $container, string $service): self
+    public static function of(Container $container, string|Ref $service): self
     {
         return new self($container, $service);
     }

--- a/src/Http/To.php
+++ b/src/Http/To.php
@@ -8,15 +8,18 @@ use Innmind\Http\{
     ServerRequest,
     Response,
 };
-use Innmind\DI\Container;
+use Innmind\DI\{
+    Container,
+    Service,
+};
 use Innmind\OperatingSystem\OperatingSystem;
 use Innmind\Router\Route\Variables;
 
 final class To
 {
-    private string $service;
+    private string|Service $service;
 
-    private function __construct(string $service)
+    private function __construct(string|Service $service)
     {
         $this->service = $service;
     }
@@ -35,7 +38,7 @@ final class To
         return $container($this->service)($request, $variables);
     }
 
-    public static function service(string $service): self
+    public static function service(string|Service $service): self
     {
         return new self($service);
     }


### PR DESCRIPTION
Version `2.2.0` introduced the use of `Innmind\DI\Service` to declare and retrieve services.

This PR finishes the support by allowing to use the enums everywhere a service can be referenced.