### PR TITLE
Reduce circular references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Use `static` closures as much as possible to reduce the probability of creating circular references by capturing `$this` as it can lead to memory root buffer exhaustion.
+
 ## 2.2.0 - 2024-03-24
 
 ### Added

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -41,10 +41,11 @@ final class Router implements RequestHandler
     public function __invoke(ServerRequest $request): Response
     {
         $match = new RequestMatcher($this->routes);
+        $notFound = $this->notFound;
 
         return $match($request)
             ->map(static fn($route) => $route->respondTo(...))
-            ->otherwise(fn() => $this->notFound)
+            ->otherwise(static fn() => $notFound)
             ->match(
                 static fn($handle) => $handle($request),
                 static fn() => Response::of(

--- a/src/Middleware/LoadDotEnv.php
+++ b/src/Middleware/LoadDotEnv.php
@@ -30,14 +30,16 @@ final class LoadDotEnv implements Middleware
 
     public function __invoke(Application $app): Application
     {
+        $folder = $this->folder;
+
         return $app->mapEnvironment(
-            fn($env, $os) => $os
+            static fn($env, $os) => $os
                 ->filesystem()
-                ->mount($this->folder)
+                ->mount($folder)
                 ->get(Name::of('.env'))
                 ->keep(Instance::of(File::class))
                 ->match(
-                    fn($file) => $this->add($env, $file),
+                    static fn($file) => self::add($env, $file),
                     static fn() => $env,
                 ),
         );
@@ -48,7 +50,7 @@ final class LoadDotEnv implements Middleware
         return new self($folder);
     }
 
-    private function add(Environment $env, File $file): Environment
+    private static function add(Environment $env, File $file): Environment
     {
         /** @psalm-suppress InvalidArgument Due to the empty sequence in the flatMap */
         return $file


### PR DESCRIPTION
## Problem

When running the `ab` command to test the performance of the http server on [`innmind/vendor-graphs`](https://github.com/Innmind/vendors-graphs). A bug appeared where some variables value was no longer available in memory.

The problem is due to too many circular references being set filling PHP's memory root buffer. Most of the circular references are due to the `Fiber`s referencing the framework `Application` object (and all its versions, as each call of the middleware creates a new object). This is the case because the closure built to then be run to handle a request capture `$this`.

`$this` is captured to simplify accessing previous properties but only the properties are needed and not the whole `Application` object.

## Solution

- Declare local variables for the properties needed inside the closure and capture these variables instead of `$this`
- Declare closures as `static` to make sure `$this` is never captured