### PR TITLE
Simplify locations where the OS and env are accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `Innmind\Framework\Application::route()` first parameter must now be expressed via a component inside the callable
 - `Innminf\Framework\Application::notFoundRequestHandler()` callable must now return an `Innmind\Immutable\Attempt<Response>`
 - `Innminf\Framework\Application::notFoundRequestHandler()` has been renamed `::routeNotFound()`
+- `Innmind\Framework\Application::mapCommand()` callable now longer has access to `OperatingSystem` and `Environment` (use services instead)
 
 ### Removed
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -134,7 +134,7 @@ final class Application
     /**
      * @psalm-mutation-free
      *
-     * @param callable(Command, Container, OperatingSystem, Environment): Command $map
+     * @param callable(Command, Container): Command $map
      *
      * @return self<I, O>
      */

--- a/src/Application.php
+++ b/src/Application.php
@@ -122,7 +122,7 @@ final class Application
     /**
      * @psalm-mutation-free
      *
-     * @param callable(Container, OperatingSystem, Environment): Command $command
+     * @param callable(Container): Command $command
      *
      * @return self<I, O>
      */

--- a/src/Application.php
+++ b/src/Application.php
@@ -146,7 +146,7 @@ final class Application
     /**
      * @psalm-mutation-free
      *
-     * @param Http\Route\Reference|callable(Pipe, Container, OperatingSystem, Environment): Component<SideEffect, Response> $handle
+     * @param Http\Route\Reference|callable(Pipe, Container): Component<SideEffect, Response> $handle
      *
      * @return self<I, O>
      */

--- a/src/Application.php
+++ b/src/Application.php
@@ -192,7 +192,7 @@ final class Application
     /**
      * @psalm-mutation-free
      *
-     * @param callable(ServerRequest, Container, OperatingSystem, Environment): Attempt<Response> $handle
+     * @param callable(ServerRequest, Container): Attempt<Response> $handle
      *
      * @return self<I, O>
      */

--- a/src/Application/Async/Http.php
+++ b/src/Application/Async/Http.php
@@ -46,7 +46,7 @@ final class Http implements Implementation
      *
      * @param \Closure(OperatingSystem, Environment): array{OperatingSystem, Environment} $map
      * @param \Closure(OperatingSystem, Environment): Builder $container
-     * @param Sequence<callable(Pipe, Container, OperatingSystem, Environment): Component<SideEffect, Response>> $routes
+     * @param Sequence<callable(Pipe, Container): Component<SideEffect, Response>> $routes
      * @param \Closure(Component<SideEffect, Response>, Container): Component<SideEffect, Response> $mapRoute
      * @param Maybe<callable(ServerRequest, Container): Attempt<Response>> $notFound
      * @param \Closure(ServerRequest, \Throwable, Container): Attempt<Response> $recover
@@ -271,7 +271,7 @@ final class Http implements Implementation
                 $container = $container($os, $env)->build();
                 $pipe = Pipe::new();
                 $routes = $routes
-                    ->map(static fn($handle) => $handle($pipe, $container, $os, $env))
+                    ->map(static fn($handle) => $handle($pipe, $container))
                     ->map(static fn($component) => $mapRoute($component, $container));
                 $router = new Router(
                     $routes,

--- a/src/Application/Async/Http.php
+++ b/src/Application/Async/Http.php
@@ -48,7 +48,7 @@ final class Http implements Implementation
      * @param \Closure(OperatingSystem, Environment): Builder $container
      * @param Sequence<callable(Pipe, Container, OperatingSystem, Environment): Component<SideEffect, Response>> $routes
      * @param \Closure(Component<SideEffect, Response>, Container): Component<SideEffect, Response> $mapRoute
-     * @param Maybe<callable(ServerRequest, Container, OperatingSystem, Environment): Attempt<Response>> $notFound
+     * @param Maybe<callable(ServerRequest, Container): Attempt<Response>> $notFound
      * @param \Closure(ServerRequest, \Throwable, Container): Attempt<Response> $recover
      */
     private function __construct(
@@ -67,7 +67,7 @@ final class Http implements Implementation
      */
     public static function of(OperatingSystem $os): self
     {
-        /** @var Maybe<callable(ServerRequest, Container, OperatingSystem, Environment): Attempt<Response>> */
+        /** @var Maybe<callable(ServerRequest, Container): Attempt<Response>> */
         $notFound = Maybe::nothing();
 
         return new self(
@@ -279,8 +279,6 @@ final class Http implements Implementation
                         static fn($handle) => static fn(ServerRequest $request) => $handle(
                             $request,
                             $container,
-                            $os,
-                            $env,
                         ),
                     ),
                     static fn($request, $e) => $recover($request, $e, $container),

--- a/src/Application/Cli.php
+++ b/src/Application/Cli.php
@@ -35,7 +35,7 @@ final class Cli implements Implementation
      *
      * @param \Closure(OperatingSystem, Environment): Builder $container
      * @param Sequence<callable(Container, OperatingSystem, Environment): Command> $commands
-     * @param \Closure(Command, Container, OperatingSystem, Environment): Command $mapCommand
+     * @param \Closure(Command, Container): Command $mapCommand
      */
     private function __construct(
         private OperatingSystem $os,
@@ -143,13 +143,9 @@ final class Cli implements Implementation
             static fn(
                 Command $command,
                 Container $service,
-                OperatingSystem $os,
-                Environment $env,
             ) => $map(
-                $previous($command, $service, $os, $env),
+                $previous($command, $service),
                 $service,
-                $os,
-                $env,
             ),
         );
     }
@@ -200,8 +196,6 @@ final class Cli implements Implementation
         $mapCommand = static fn(Command $command): Command => $mapCommand(
             $command,
             $container,
-            $os,
-            $env,
         );
         $commands = $this->commands->map(static fn($command) => new Defer(
             \Closure::fromCallable($command),

--- a/src/Application/Cli.php
+++ b/src/Application/Cli.php
@@ -34,7 +34,7 @@ final class Cli implements Implementation
      * @psalm-mutation-free
      *
      * @param \Closure(OperatingSystem, Environment): Builder $container
-     * @param Sequence<callable(Container, OperatingSystem, Environment): Command> $commands
+     * @param Sequence<callable(Container): Command> $commands
      * @param \Closure(Command, Container): Command $mapCommand
      */
     private function __construct(
@@ -200,8 +200,6 @@ final class Cli implements Implementation
         $commands = $this->commands->map(static fn($command) => new Defer(
             \Closure::fromCallable($command),
             $container,
-            $os,
-            $env,
             $mapCommand,
         ));
 

--- a/src/Application/Http.php
+++ b/src/Application/Http.php
@@ -40,7 +40,7 @@ final class Http implements Implementation
      * @param \Closure(OperatingSystem, Environment): Builder $container
      * @param Sequence<callable(Pipe, Container, OperatingSystem, Environment): Component<SideEffect, Response>> $routes
      * @param \Closure(Component<SideEffect, Response>, Container): Component<SideEffect, Response> $mapRoute
-     * @param Maybe<callable(ServerRequest, Container, OperatingSystem, Environment): Attempt<Response>> $notFound
+     * @param Maybe<callable(ServerRequest, Container): Attempt<Response>> $notFound
      * @param \Closure(ServerRequest, \Throwable, Container): Attempt<Response> $recover
      */
     private function __construct(
@@ -59,7 +59,7 @@ final class Http implements Implementation
      */
     public static function of(OperatingSystem $os, Environment $env): self
     {
-        /** @var Maybe<callable(ServerRequest, Container, OperatingSystem, Environment): Attempt<Response>> */
+        /** @var Maybe<callable(ServerRequest, Container): Attempt<Response>> */
         $notFound = Maybe::nothing();
 
         return new self(
@@ -245,8 +245,6 @@ final class Http implements Implementation
                 static fn($handle) => static fn(ServerRequest $request) => $handle(
                     $request,
                     $container,
-                    $os,
-                    $env,
                 ),
             ),
             static fn($request, $e) => $recover($request, $e, $container),

--- a/src/Application/Http.php
+++ b/src/Application/Http.php
@@ -38,7 +38,7 @@ final class Http implements Implementation
      * @psalm-mutation-free
      *
      * @param \Closure(OperatingSystem, Environment): Builder $container
-     * @param Sequence<callable(Pipe, Container, OperatingSystem, Environment): Component<SideEffect, Response>> $routes
+     * @param Sequence<callable(Pipe, Container): Component<SideEffect, Response>> $routes
      * @param \Closure(Component<SideEffect, Response>, Container): Component<SideEffect, Response> $mapRoute
      * @param Maybe<callable(ServerRequest, Container): Attempt<Response>> $notFound
      * @param \Closure(ServerRequest, \Throwable, Container): Attempt<Response> $recover
@@ -230,14 +230,12 @@ final class Http implements Implementation
     public function run($input)
     {
         $container = ($this->container)($this->os, $this->env)->build();
-        $os = $this->os;
-        $env = $this->env;
         $mapRoute = $this->mapRoute;
         $recover = $this->recover;
         $pipe = Pipe::new();
         $routes = $this
             ->routes
-            ->map(static fn($handle) => $handle($pipe, $container, $os, $env))
+            ->map(static fn($handle) => $handle($pipe, $container))
             ->map(static fn($component) => $mapRoute($component, $container));
         $router = new Router(
             $routes,

--- a/src/Application/Implementation.php
+++ b/src/Application/Implementation.php
@@ -81,7 +81,7 @@ interface Implementation
     /**
      * @psalm-mutation-free
      *
-     * @param callable(Pipe, Container, OperatingSystem, Environment): Component<SideEffect, Response> $handle
+     * @param callable(Pipe, Container): Component<SideEffect, Response> $handle
      *
      * @return self<I, O>
      */

--- a/src/Application/Implementation.php
+++ b/src/Application/Implementation.php
@@ -99,7 +99,7 @@ interface Implementation
     /**
      * @psalm-mutation-free
      *
-     * @param callable(ServerRequest, Container, OperatingSystem, Environment): Attempt<Response> $handle
+     * @param callable(ServerRequest, Container): Attempt<Response> $handle
      *
      * @return self<I, O>
      */

--- a/src/Application/Implementation.php
+++ b/src/Application/Implementation.php
@@ -63,7 +63,7 @@ interface Implementation
     /**
      * @psalm-mutation-free
      *
-     * @param callable(Container, OperatingSystem, Environment): Command $command
+     * @param callable(Container): Command $command
      *
      * @return self<I, O>
      */

--- a/src/Application/Implementation.php
+++ b/src/Application/Implementation.php
@@ -72,7 +72,7 @@ interface Implementation
     /**
      * @psalm-mutation-free
      *
-     * @param callable(Command, Container, OperatingSystem, Environment): Command $map
+     * @param callable(Command, Container): Command $map
      *
      * @return self<I, O>
      */

--- a/src/Cli/Command/Defer.php
+++ b/src/Cli/Command/Defer.php
@@ -3,13 +3,11 @@ declare(strict_types = 1);
 
 namespace Innmind\Framework\Cli\Command;
 
-use Innmind\Framework\Environment;
 use Innmind\CLI\{
     Command,
     Command\Usage,
     Console,
 };
-use Innmind\OperatingSystem\OperatingSystem;
 use Innmind\DI\Container;
 use Innmind\Immutable\Attempt;
 
@@ -21,14 +19,12 @@ final class Defer implements Command
     private ?Command $command = null;
 
     /**
-     * @param \Closure(Container, OperatingSystem, Environment): Command $build
+     * @param \Closure(Container): Command $build
      * @param \Closure(Command): Command $map
      */
     public function __construct(
         private \Closure $build,
         private Container $locate,
-        private OperatingSystem $os,
-        private Environment $env,
         private \Closure $map,
     ) {
     }
@@ -61,6 +57,6 @@ final class Defer implements Command
          * @psalm-suppress PropertyTypeCoercion
          * @var Command
          */
-        return $this->command ??= ($this->build)($this->locate, $this->os, $this->env);
+        return $this->command ??= ($this->build)($this->locate);
     }
 }

--- a/src/Http/Route/Reference.php
+++ b/src/Http/Route/Reference.php
@@ -3,8 +3,6 @@ declare(strict_types = 1);
 
 namespace Innmind\Framework\Http\Route;
 
-use Innmind\Framework\Environment;
-use Innmind\OperatingSystem\OperatingSystem;
 use Innmind\DI\Container;
 use Innmind\Router\{
     Component,
@@ -19,7 +17,7 @@ use Innmind\Immutable\SideEffect;
 interface Reference extends \UnitEnum
 {
     /**
-     * @return callable(Pipe, Container, OperatingSystem, Environment): Component<SideEffect, Response>
+     * @return callable(Pipe, Container): Component<SideEffect, Response>
      */
     public function route(): callable;
 }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -633,6 +633,7 @@ class ApplicationTest extends TestCase
             )
             ->prove(function($inputs, $interactive, $variables) {
                 $app = Application::cli(Factory::build(), Environment::test($variables))
+                    ->service(Services::service, static fn($_, $__, $env) => $env)
                     ->map(new class implements Middleware {
                         public function __invoke(Application $app): Application
                         {
@@ -663,7 +664,7 @@ class ApplicationTest extends TestCase
                             });
                         }
                     })
-                    ->command(static fn($_, $__, $env) => new class($env) implements Command {
+                    ->command(static fn($get) => new class($get(Services::service)) implements Command {
                         public function __construct(
                             private $env,
                         ) {
@@ -722,9 +723,10 @@ class ApplicationTest extends TestCase
                 };
 
                 $app = Application::cli(Factory::build(), Environment::test($variables))
+                    ->service(Services::service, static fn($_, $__, $env) => $env)
                     ->map(Optional::of(Unknown::class, static fn() => throw new \Exception))
                     ->map(Optional::of($middleware::class, static fn() => $middleware))
-                    ->command(static fn($_, $__, $env) => new class($env) implements Command {
+                    ->command(static fn($get) => new class($get(Services::service)) implements Command {
                         public function __construct(
                             private $env,
                         ) {
@@ -773,8 +775,9 @@ class ApplicationTest extends TestCase
             )
             ->prove(function($inputs, $interactive, $variables) {
                 $app = Application::cli(Factory::build(), Environment::test($variables))
+                    ->service(Services::service, static fn($_, $__, $env) => $env)
                     ->map(LoadDotEnv::at(Path::of(__DIR__.'/../fixtures/')))
-                    ->command(static fn($_, $__, $env) => new class($env) implements Command {
+                    ->command(static fn($get) => new class($get(Services::service)) implements Command {
                         public function __construct(
                             private $env,
                         ) {


### PR DESCRIPTION
They're now only accessible when building services. The goal is to force the use of services, otherwise too much logic can be put in the framework configuration (thus reducing testability).

Yet people can set the OS and environment as services and access them like before with little extra work.