### PR TITLE
Reduce routes memory footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `Innmind\Framework\Application::mapRoutes()`
 
+### Changed
+
+- Reduced routes memory footprint
+
 ## 4.0.2 - 2026-04-12
 
 ### Fixed

--- a/src/Application/Async/Http.php
+++ b/src/Application/Async/Http.php
@@ -77,7 +77,7 @@ final class Http implements Implementation
             $os,
             static fn(OperatingSystem $os, Environment $env) => [$os, $env],
             static fn() => Builder::new(),
-            Sequence::lazyStartingWith(),
+            Sequence::of(),
             static fn(Component $component) => $component,
             static fn(Component $component) => $component,
             $notFound,
@@ -285,7 +285,9 @@ final class Http implements Implementation
     {
         $map = $this->map;
         $container = $this->container;
-        $routes = $this->routes;
+        $routes = Sequence::lazyStartingWith($this->routes)->flatMap(
+            static fn($routes) => $routes,
+        );
         $notFound = $this->notFound;
         $mapRoute = $this->mapRoute;
         $mapRoutes = $this->mapRoutes;

--- a/src/Application/Http.php
+++ b/src/Application/Http.php
@@ -68,7 +68,7 @@ final class Http implements Implementation
             $os,
             $env,
             static fn() => Builder::new(),
-            Sequence::lazyStartingWith(),
+            Sequence::of(),
             static fn(Component $component) => $component,
             static fn(Component $component) => $component,
             $notFound,
@@ -267,8 +267,8 @@ final class Http implements Implementation
         $mapRoutes = $this->mapRoutes;
         $recover = $this->recover;
         $pipe = Pipe::new();
-        $routes = $this
-            ->routes
+        $routes = Sequence::lazyStartingWith($this->routes)
+            ->flatMap(static fn($routes) => $routes)
             ->map(static fn($handle) => $handle($pipe, $container))
             ->map(static fn($component) => $mapRoute($component, $container));
         $router = new Router(


### PR DESCRIPTION
Instead of using a lazy `Sequence` from the start, that creates a new generator for each new route, a lazy `Sequence` built from the in memory one is built just before calling each handler.

This way handlers declared after the matched route are still not called, while using a single array to store all the callables (instead of n generators).